### PR TITLE
Add contact form page and API

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,17 +3,19 @@ import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import Blog from './pages/Blog.jsx';
 import Careers from './pages/Careers.jsx';
+import Contact from './pages/Contact.jsx';
 
 export default function App() {
   return (
     <Router>
       <nav>
-        <Link to="/">Home</Link> | <Link to="/blog">Blog</Link> | <Link to="/careers">Careers</Link>
+        <Link to="/">Home</Link> | <Link to="/blog">Blog</Link> | <Link to="/careers">Careers</Link> | <Link to="/contact">Contact</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/blog" element={<Blog />} />
         <Route path="/careers" element={<Careers />} />
+        <Route path="/contact" element={<Contact />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Contact.jsx
+++ b/client/src/pages/Contact.jsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+
+export default function Contact() {
+  const [messages, setMessages] = useState([]);
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  useEffect(() => {
+    fetch('/api/contacts').then(res => res.json()).then(setMessages);
+  }, []);
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/contacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    if (res.ok) {
+      const msg = await res.json();
+      setMessages([msg, ...messages]);
+      setForm({ name: '', email: '', message: '' });
+    }
+  };
+
+  return (
+    <div>
+      <h1>Contact Us</h1>
+      <form onSubmit={submit}>
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          placeholder="Email"
+          value={form.email}
+          onChange={e => setForm({ ...form, email: e.target.value })}
+        />
+        <textarea
+          placeholder="Message"
+          value={form.message}
+          onChange={e => setForm({ ...form, message: e.target.value })}
+        />
+        <button type="submit">Send</button>
+      </form>
+      <ul>
+        {messages.map(m => (
+          <li key={m._id}>
+            <strong>{m.name}</strong> ({m.email})
+            <p>{m.message}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import cors from 'cors';
 import blogs from './routes/blogs.js';
 import jobs from './routes/jobs.js';
+import contacts from './routes/contacts.js';
 
 const app = express();
 app.use(cors());
@@ -15,6 +16,7 @@ mongoose.connect(MONGO_URL, { useNewUrlParser: true, useUnifiedTopology: true })
 
 app.use('/api/blogs', blogs);
 app.use('/api/jobs', jobs);
+app.use('/api/contacts', contacts);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {

--- a/server/models/Contact.js
+++ b/server/models/Contact.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const ContactSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  message: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('Contact', ContactSchema);

--- a/server/routes/contacts.js
+++ b/server/routes/contacts.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import Contact from '../models/Contact.js';
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const msgs = await Contact.find().sort({ createdAt: -1 });
+  res.json(msgs);
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const msg = await Contact.create(req.body);
+    res.status(201).json(msg);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Contact React page with form to send messages
- expose `/api/contacts` on Express server for listing and posting messages
- wire up contact link in app router

## Testing
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0adc764e883219f417eb69f2ffbb8